### PR TITLE
Move transferables from initializer to method call

### DIFF
--- a/sockx/__init__.py
+++ b/sockx/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.1-alpha-8"
+__version__ = "0.1-alpha-9"

--- a/sockx/sender/sender.py
+++ b/sockx/sender/sender.py
@@ -8,17 +8,17 @@ from .udp_message_sender import UDPMessageSender
 
 class Sender:
     @staticmethod
-    def get_sender(host, message=None, filename=None, port=PORT, protocol=PROTOCOL):
+    def get_sender(host, port=PORT, protocol=PROTOCOL, is_message=False):
         if protocol == "TCP":
-            if filename != None:
-                return TCPFileSender(filename=filename, host=host, port=port)
+            if not is_message:
+                return TCPFileSender(host=host, port=port)
 
-            return TCPMessageSender(message=message, host=host, port=port)
+            return TCPMessageSender(host=host, port=port)
         elif protocol == "UDP":
-            if filename != None:
-                return UDPFileSender(filename=filename, host=host, port=port)
+            if not is_message:
+                return UDPFileSender(host=host, port=port)
 
-            return UDPMessageSender(message=message, host=host, port=port)
+            return UDPMessageSender(host=host, port=port)
         else:
             raise error.InvalidSocketProtocol(
                 message=f"Protocol {protocol} not known, cannot create sender instance!"

--- a/sockx/sender/tcp_file_sender.py
+++ b/sockx/sender/tcp_file_sender.py
@@ -10,14 +10,13 @@ from ..utils.error import ConnectionFailure
 
 
 class TCPFileSender:
-    def __init__(self, filename, host, port=PORT):
-        self.__filename = filename
+    def __init__(self, host, port=PORT):
         self.__host = host
         self.__port = port
 
-    def send_file(self):
+    def send_file(self, filename):
         # Get the file size
-        filesize = os.path.getsize(self.__filename)
+        filesize = os.path.getsize(filename)
 
         # Create the client TCP socket
         s = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
@@ -36,17 +35,17 @@ class TCPFileSender:
         print("[+] Connected.")
 
         # Send the filename and filesize
-        s.send(f"{self.__filename}{SEPARATOR}{filesize}".encode())
+        s.send(f"{filename}{SEPARATOR}{filesize}".encode())
 
         # Start sending the file
         progress = tqdm.tqdm(
             range(filesize),
-            f"Sending {self.__filename}",
+            f"Sending {filename}",
             unit="B",
             unit_scale=True,
             unit_divisor=1024,
         )
-        with open(self.__filename, "rb") as f:
+        with open(filename, "rb") as f:
             while True:
                 # Read the bytes from the file
                 bytes_read = f.read(BUFFER_SIZE)

--- a/sockx/sender/tcp_message_sender.py
+++ b/sockx/sender/tcp_message_sender.py
@@ -8,12 +8,11 @@ from ..utils.error import ConnectionFailure
 
 
 class TCPMessageSender:
-    def __init__(self, message, host, port=PORT):
-        self.__message = message
+    def __init__(self, host, port=PORT):
         self.__host = host
         self.__port = port
 
-    def send_message(self):
+    def send_message(self, message):
         # Create the client TCP socket
         s = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
 
@@ -31,7 +30,7 @@ class TCPMessageSender:
         print("[+] Connected.")
 
         # Send the message
-        s.send(self.__message.encode())
+        s.send(message.encode())
 
         # Close the socket
         s.close()

--- a/sockx/sender/udp_file_sender.py
+++ b/sockx/sender/udp_file_sender.py
@@ -9,14 +9,13 @@ from ..constants import *
 
 
 class UDPFileSender:
-    def __init__(self, filename, host, port=PORT):
-        self.__filename = filename
+    def __init__(self, host, port=PORT):
         self.__host = host
         self.__port = port
 
-    def send_file(self):
+    def send_file(self, filename):
         # Get the file size
-        filesize = os.path.getsize(self.__filename)
+        filesize = os.path.getsize(filename)
 
         # Create the client UDP socket
         s = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
@@ -25,17 +24,17 @@ class UDPFileSender:
         addr = (self.__host, self.__port)
 
         # Send the filename and filesize
-        s.sendto(f"{self.__filename}{SEPARATOR}{filesize}".encode(), addr)
+        s.sendto(f"{filename}{SEPARATOR}{filesize}".encode(), addr)
 
         # Start sending the file
         progress = tqdm.tqdm(
             range(filesize),
-            f"Sending {self.__filename}",
+            f"Sending {filename}",
             unit="B",
             unit_scale=True,
             unit_divisor=1024,
         )
-        with open(self.__filename, "rb") as f:
+        with open(filename, "rb") as f:
             while True:
                 # Read the bytes from the file
                 bytes_read = f.read(BUFFER_SIZE)

--- a/sockx/sender/udp_message_sender.py
+++ b/sockx/sender/udp_message_sender.py
@@ -7,12 +7,11 @@ from ..constants import *
 
 
 class UDPMessageSender:
-    def __init__(self, message, host, port=PORT):
-        self.__message = message
+    def __init__(self, host, port=PORT):
         self.__host = host
         self.__port = port
 
-    def send_message(self):
+    def send_message(self, message):
         # Create the client UDP socket
         s = socket.socket(family=socket.AF_INET, type=socket.SOCK_DGRAM)
 
@@ -20,4 +19,4 @@ class UDPMessageSender:
         addr = (self.__host, self.__port)
 
         # Send the filename and filesize
-        s.sendto(self.__message.encode(), addr)
+        s.sendto(message.encode(), addr)


### PR DESCRIPTION
Closes #1 

**Implementation**

1. Remove message/filename (transferables) from initializer and put them as parameters in corresponding methods.
2. Decide which object to return in Sender class' static method based on a boolean flag `is_message`. This method was already used in receiver side, now both sender and receiver have same params. 
3. Corresponding change made in sockapp. Refer PR <a href="https://github.com/pulse-net/sockapp/pull/42">#42</a> from sockapp.